### PR TITLE
Dtspo4185 fix azuread errors

### DIFF
--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -8,7 +8,7 @@ data "azuread_group" "aad_group" {
   display_name = "DTS Contributors (sub:dts-sharedservices-${var.environment})"
 }
 data "azuread_group" "platform_group" {
-  display_name = "DTS Platform Operations"
+  object_id = "e7ea2042-4ced-45dd-8ae3-e051c6551789"
 }
 data "azuread_group" "developers_group" {
   display_name = var.developers_group

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -3,9 +3,6 @@ locals {
   sub_env = var.environment == "ptlsbox" ? "ptl-sbox" : var.environment
   aad_group_name = contains(["ptlsbox", "ptl"], var.environment) ? "DTS Contributors (sub:dts-sharedservices${local.sub_env})" : "DTS Contributors (sub:dts-sharedservices-${local.sub_env})"
   
-  # Temporary until all key vaults have been updated to use the naming convention
-  key_vault_name = contains(["ptlsbox", "ptl"], var.environment) ? "dtssds${var.environment}" : "${lower(replace(data.azurerm_subscription.current.display_name, "-", ""))}kv"
-  
 }
 data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -1,3 +1,12 @@
+locals {
+  
+  sub_env = var.environment == "ptlsbox" ? "ptl-sbox" : var.environment
+  aad_group_name = contains(["ptlsbox", "ptl"], var.environment) ? "DTS Contributors (sub:dts-sharedservices${local.sub_env})" : "DTS Contributors (sub:dts-sharedservices-${local.sub_env})"
+  
+  # Temporary until all key vaults have been updated to use the naming convention
+  key_vault_name = contains(["ptlsbox", "ptl"], var.environment) ? "dtssds${var.environment}" : "${lower(replace(data.azurerm_subscription.current.display_name, "-", ""))}kv"
+  
+}
 data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -2,14 +2,14 @@ data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 
 data "azuread_group" "operations_group" {
-  name = "DTS Operations (env:${var.environment})"
+  display_name = "DTS Operations (env:${var.environment})"
 }
 data "azuread_group" "aad_group" {
-  name = "DTS Contributors (sub:dts-sharedservices-${var.environment})"
+  display_name = "DTS Contributors (sub:dts-sharedservices-${var.environment})"
 }
 data "azuread_group" "platform_group" {
-  name = "DTS Platform Operations"
+  display_name = "DTS Platform Operations"
 }
 data "azuread_group" "developers_group" {
-  name = var.developers_group
+  display_name = var.developers_group
 }

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -14,7 +14,7 @@ data "azuread_group" "operations_group" {
   display_name = "DTS Operations (env:${var.environment})"
 }
 data "azuread_group" "aad_group" {
-  display_name = "DTS Contributors (sub:dts-sharedservices-${var.environment})"
+  display_name = local.aad_group_name
 }
 data "azuread_group" "platform_group" {
   object_id = "e7ea2042-4ced-45dd-8ae3-e051c6551789"

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -1,8 +1,8 @@
 locals {
-  
-  sub_env = var.environment == "ptlsbox" ? "ptl-sbox" : var.environment
+
+  sub_env        = var.environment == "ptlsbox" ? "ptl-sbox" : var.environment
   aad_group_name = contains(["ptlsbox", "ptl"], var.environment) ? "DTS Contributors (sub:dts-sharedservices${local.sub_env})" : "DTS Contributors (sub:dts-sharedservices-${local.sub_env})"
-  
+
 }
 data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
@@ -14,7 +14,7 @@ data "azuread_group" "aad_group" {
   display_name = local.aad_group_name
 }
 data "azuread_group" "platform_group" {
-  display_name = "DTS Platform Operations"
+  display_name     = "DTS Platform Operations"
   security_enabled = true
 }
 data "azuread_group" "developers_group" {

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -1,25 +1,15 @@
-locals {
-  
-  sub_env = var.environment == "ptlsbox" ? "ptl-sbox" : var.environment
-  aad_group_name = contains(["ptlsbox", "ptl"], var.environment) ? "DTS Contributors (sub:dts-sharedservices${local.sub_env})" : "DTS Contributors (sub:dts-sharedservices-${local.sub_env})"
-  
-  # Temporary until all key vaults have been updated to use the naming convention
-  key_vault_name = contains(["ptlsbox", "ptl"], var.environment) ? "dtssds${var.environment}" : "${lower(replace(data.azurerm_subscription.current.display_name, "-", ""))}kv"
-  
-}
-
 data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 
 data "azuread_group" "operations_group" {
-  display_name = "DTS Operations (env:${var.environment})"
+  name = "DTS Operations (env:${var.environment})"
 }
 data "azuread_group" "aad_group" {
-  display_name = local.aad_group_name
+  name = "DTS Contributors (sub:dts-sharedservices-${var.environment})"
 }
 data "azuread_group" "platform_group" {
-  display_name = "DTS Platform Operations"
+  name = "DTS Platform Operations"
 }
 data "azuread_group" "developers_group" {
-  display_name = var.developers_group
+  name = var.developers_group
 }

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -17,7 +17,8 @@ data "azuread_group" "aad_group" {
   display_name = local.aad_group_name
 }
 data "azuread_group" "platform_group" {
-  object_id = "e7ea2042-4ced-45dd-8ae3-e051c6551789"
+  display_name = "DTS Platform Operations"
+  security_enabled = true
 }
 data "azuread_group" "developers_group" {
   display_name = var.developers_group

--- a/20-key-vault.tf
+++ b/20-key-vault.tf
@@ -2,8 +2,9 @@
 # Genesis - Infrastructure Key Vault
 #--------------------------------------------------------------
 
+
 resource "azurerm_key_vault" "key_vault" {
-  name                = local.key_vault_name
+  name                = "${lower(replace(data.azurerm_subscription.current.display_name, "-", ""))}kv"
   resource_group_name = azurerm_resource_group.genesis_resource_group.name
   location            = var.location
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

As part of DTSPO4185 i noticed that due to azuread moving to v 2.0.1 that the name field was no longer accepted and has changed to display_name.

name field updated to use display_name.

Had to add locals so that the genesis module will work with cft ptlsbox environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
