### PR TITLE
fix/kv-object-id-error

### DIFF
--- a/20-key-vault.tf
+++ b/20-key-vault.tf
@@ -24,7 +24,7 @@ resource "azurerm_key_vault_access_policy" "key_vault_access_policy" {
   key_vault_id = azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azuread_group.aad_group.id
+  object_id = data.azuread_group.aad_group.object_id
 
   key_permissions = [
     "Create",
@@ -60,7 +60,7 @@ resource "azurerm_key_vault_access_policy" "developers_group_access_policy" {
   key_vault_id = azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azuread_group.developers_group.id
+  object_id = data.azuread_group.developers_group.object_id
 
   key_permissions = [
     "Encrypt",
@@ -77,7 +77,7 @@ resource "azurerm_key_vault_access_policy" "ops_group_access_policy" {
   key_vault_id = azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azuread_group.operations_group.id
+  object_id = data.azuread_group.operations_group.object_id
 
   key_permissions = [
     "Decrypt",
@@ -104,7 +104,7 @@ resource "azurerm_key_vault_access_policy" "platform_operations" {
   key_vault_id = azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azuread_group.platform_group.id
+  object_id = data.azuread_group.platform_group.object_id
 
   key_permissions = [
     "Create",


### PR DESCRIPTION
### Change description

updated data reference in keyvault from `xx.id` -> `xx.object_id` according to terraform registry docs https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group#object_id
will unblock ado pipeline currently facing errors due to this https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=665299&view=logs&j=f461a02b-10e8-52f8-1418-1c32ce657b73&t=8ea29a5d-62fb-519b-f1b8-a061b79de710

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
